### PR TITLE
Widen IFilter.value, add documentation for computed column filtering/sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphQL-Connections :diamond_shape_with_a_dot_inside:
 
-- [GraphQL-Connections :diamond_shape_with_a_dot_inside:](#graphql-connections-diamondshapewithadotinside)
+- [GraphQL-Connections :diamond_shape_with_a_dot_inside:](#graphql-connections-diamond_shape_with_a_dot_inside)
   - [Install](#install)
   - [About](#about)
   - [Run locally](#run-locally)
@@ -20,7 +20,7 @@
         - [A. set the `Node` type](#a-set-the-node-type)
         - [B. add inputArgs](#b-add-inputargs)
         - [C. specify an attributeMap](#c-specify-an-attributemap)
-      - [2. build the query query](#2-build-the-query-query)
+      - [2. build the query](#2-build-the-query)
       - [3. execute the query and build the `connection`](#3-execute-the-query-and-build-the-connection)
     - [Options](#options)
       - [contextOptions](#contextoptions)
@@ -38,7 +38,7 @@
   - [Extensions](#extensions)
   - [Architecture](#architecture)
   - [Search](#search)
-
+  - [Filtering on computed columns](#filtering-on-computed-columns)
 
 ## Install
 
@@ -50,7 +50,7 @@ npm install --save graphql-connections#v2.2.0
 
 ## About
 
-`GraphQL-Connections` helps handle the traversal of edges between nodes. 
+`GraphQL-Connections` helps handle the traversal of edges between nodes.
 
 In a graph, nodes connect to other nodes via edges. In the relay graphql spec, multiple edges can be represented as a single `Connection` type, which has the signature:
 
@@ -66,44 +66,42 @@ type Connection {
 }
 ```
 
-A connection object is returned to a user when a `query request` asks for multiple child nodes connected to a parent node. 
+A connection object is returned to a user when a `query request` asks for multiple child nodes connected to a parent node.
 For example, a music artist has multiple songs. In order to get all the `songs` for an `artist` you would write the graphql query request:
 
 ```graphql
 query {
-  artist(id: 1) {
-    songs {
-      songName
-      songLength
+    artist(id: 1) {
+        songs {
+            songName
+            songLength
+        }
     }
-  }
 }
-
 ```
 
-However, sometimes you may only want a portion of the songs returned to you. To allow for this scenario, a `connection` is used to represent the response type of a `song`. 
+However, sometimes you may only want a portion of the songs returned to you. To allow for this scenario, a `connection` is used to represent the response type of a `song`.
 
 ```graphql
 query {
-  artist(id: 1) {
-    songs {
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
-      edges {
-        cursor
-        node {
-          songName
-          songLength
+    artist(id: 1) {
+        songs {
+            pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+            }
+            edges {
+                cursor
+                node {
+                    songName
+                    songLength
+                }
+            }
         }
-      }
     }
-  }
 }
-
 ```
 
 You can use the `cursors` (`startCursor`, `endCursor`, or `cursor`) to get the next set of edges.
@@ -136,74 +134,72 @@ The above logic is controlled by the `connectionManager`. It can be added to a r
 1. Create a cursor for paging through a node's edges
 2. Handle movement through a node's edges using an existing cursor.
 3. Support multiple input types that can sort, group, limit, and filter the edges in a connection
- 
 
 ## Run locally
 
-1. Run the migrations 
-   - `NODE_ENV=development npm run migrate:sqlite:latest`
-   - `NODE_ENV=development npm run migrate:mysql:latest`
-2. Seed the database 
-   - `NODE_ENV=development npm run seed:sqlite:run`
-   - `NODE_ENV=development npm run seed:mysql:run`
-3. Run the dev server 
-   - `npm run dev:sqlite` (search is not supported)
-   - `npm run dev:mysql` (search IS supported :))
+1. Run the migrations
+    - `NODE_ENV=development npm run migrate:sqlite:latest`
+    - `NODE_ENV=development npm run migrate:mysql:latest`
+2. Seed the database
+    - `NODE_ENV=development npm run seed:sqlite:run`
+    - `NODE_ENV=development npm run seed:mysql:run`
+3. Run the dev server
+    - `npm run dev:sqlite` (search is not supported)
+    - `npm run dev:mysql` (search IS supported :))
 4. Visit the GraphQL playground [http://localhost:4000/graphql](http://localhost:4000/graphql)
 5. Run some queries!
 
 ```graphql
 query {
-  users(
-      first: 100,
-      orderBy: "haircolor",
-      filter: { and: [
-        {field: "id", operator: ">", value: "19990"},
-        {field: "age", operator: "<", value: "90"},
-      ]},
-      search: "random search term"
-  ) {
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
+    users(
+        first: 100
+        orderBy: "haircolor"
+        filter: {
+            and: [
+                {field: "id", operator: ">", value: "19990"}
+                {field: "age", operator: "<", value: "90"}
+            ]
+        }
+        search: "random search term"
+    ) {
+        pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+        }
+        edges {
+            cursor
+            node {
+                username
+                lastname
+                id
+                haircolor
+                bio
+            }
+        }
     }
-    edges {
-      cursor
-      node {
-        username
-        lastname
-        id
-        haircolor
-        bio
-      }
-    }
-  }
 }
 ```
 
 ```graphql
 query {
-  users(
-    first: 10,
-    after: "eyJmaXJzdFJlc3VsdElkIjoxOTk5MiwibGFzdFJlc3VsdE"
-  ) {
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
+    users(first: 10, after: "eyJmaXJzdFJlc3VsdElkIjoxOTk5MiwibGFzdFJlc3VsdE") {
+        pageInfo {
+            hasNextPage
+            hasPreviousPage
+        }
+        edges {
+            cursor
+            node {
+                username
+                lastname
+                id
+                haircolor
+                bio
+            }
+        }
     }
-    edges {
-      cursor
-      node {
-        username
-        lastname
-        id
-        haircolor
-        bio
-      }
-    }
-  }
 }
 ```
 
@@ -217,16 +213,16 @@ At the very least you should add `Before`, `After` and `First`, `Last` because t
 
 ```graphql
 type Query {
-  users(
-      first: First
-      last: Last
-      orderBy: OrderBy
-      orderDir: OrderDir
-      before: Before
-      after: After
-      filter: Filter
-      search: Search
-  ): QueryUsersConnection
+    users(
+        first: First
+        last: Last
+        orderBy: OrderBy
+        orderDir: OrderDir
+        before: Before
+        after: After
+        filter: Filter
+        search: Search
+    ): QueryUsersConnection
 }
 ```
 
@@ -334,15 +330,13 @@ import {ConnectionManager, INode} from 'graphql-connections';
 
 const resolver = async (obj, inputArgs) => {
     // create a new node connection instance
-    const nodeConnection = new ConnectionManager<
-        INode,
-    >(inputArgs, attributeMap);
+    const nodeConnection = new ConnectionManager<INode>(inputArgs, attributeMap);
 
     // apply the connection to the queryBuilder
     const appliedQuery = nodeConnection.createQuery(queryBuilder.clone());
 
     // run the query
-    const result = await appliedQuery.select()
+    const result = await appliedQuery.select();
 
     // add the result to the nodeConnection
     nodeConnection.addResult(result);
@@ -352,7 +346,7 @@ const resolver = async (obj, inputArgs) => {
         pageInfo: nodeConnection.pageInfo,
         edges: nodeConnection.edges
     };
-}
+};
 ```
 
 types:
@@ -383,7 +377,7 @@ interface IInAttributeMap {
 interface INodeConnection {
   createQuery: (KnexQueryBuilder) => KnexQueryBuilder
   addResult: (KnexQueryResult) => void
-  pageInfo?: IPageInfo 
+  pageInfo?: IPageInfo
   edges?: IEdge[]
 
 interface IPageInfo: {
@@ -392,9 +386,9 @@ interface IPageInfo: {
   startCursor: string
   endCursor: string
 }
-  
+
 interface IEdge {
-  cursor: string; 
+  cursor: string;
   node: INode
 }
 ```
@@ -406,10 +400,10 @@ All types can be found in [src/types.ts](./src/types.ts)
 A `nodeConnection` is used to handle connections.
 
 To use a `nodeConnection` you will have to:
- 1. initialize the nodeConnection
- 2. build the connection query
- 3.  build the connection from the executed query
 
+1.  initialize the nodeConnection
+2.  build the connection query
+3.  build the connection from the executed query
 
 #### 1. Initialize the `nodeConnection`
 
@@ -419,7 +413,7 @@ To correctly initialize, you will need to supply a `Node` type, the `inputArgs` 
 
 The nodes that are part of a connection need a type. The returned edges will contain nodes of this type.
 
- For example, in this case we create an `IUserNode`
+For example, in this case we create an `IUserNode`
 
 ```typescript
 interface IUserNode extends INode {
@@ -439,7 +433,7 @@ interface IInputArgs {
     first?: number; // page size
     last?: number; // page size
     orderBy?: string; // order by a node field
-    orderDir: 'asc' | 'desc'
+    orderDir: 'asc' | 'desc';
     filter?: IOperationFilter;
 }
 
@@ -462,46 +456,52 @@ An example query with a filter could look like:
 
 ```graphql
 query {
-  users(filter:  { 
-      or: [
-        { field: "age", operator: "=", value: "40"},
-        { field: "age", operator: "<", value: "30"},
-        { and: [
-          { field: "haircolor", operator: "=", value: "blue"},
-          { field: "age", operator: "=", value: "70"},
-          { or: [
-            { field: "username", operator: "=", value: "Ellie86"},
-            { field: "username", operator: "=", value: "Euna_Oberbrunner"},
-          ]}
-        ]},
-      ],
-    }) {
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
+    users(
+        filter: {
+            or: [
+                {field: "age", operator: "=", value: "40"}
+                {field: "age", operator: "<", value: "30"}
+                {
+                    and: [
+                        {field: "haircolor", operator: "=", value: "blue"}
+                        {field: "age", operator: "=", value: "70"}
+                        {
+                            or: [
+                                {field: "username", operator: "=", value: "Ellie86"}
+                                {field: "username", operator: "=", value: "Euna_Oberbrunner"}
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ) {
+        pageInfo {
+            hasNextPage
+            hasPreviousPage
+        }
+        edges {
+            cursor
+            node {
+                id
+                age
+                haircolor
+                lastname
+                username
+            }
+        }
     }
-    edges {
-      cursor
-      node {
-        id
-        age
-        haircolor
-        lastname
-        username
-      }
-    }
-  }
 }
 ```
 
 This would yield a sql query equivalent to:
 
 ```sql
-  SELECT * 
-    FROM `mock` 
-   WHERE `age` = '40' OR `age` < '30' OR (`haircolor` = 'blue' AND `age` = '70' AND (`username` = 'Ellie86' OR `username` = 'Euna_Oberbrunner')) 
-ORDER BY `id` 
-     ASC 
+  SELECT *
+    FROM `mock`
+   WHERE `age` = '40' OR `age` < '30' OR (`haircolor` = 'blue' AND `age` = '70' AND (`username` = 'Ellie86' OR `username` = 'Euna_Oberbrunner'))
+ORDER BY `id`
+     ASC
    LIMIT 1001
 ```
 
@@ -511,16 +511,16 @@ ORDER BY `id`
 
 Only fields defined in the attribute map can be `orderBy` or `filtered` on. An error will be thrown if you try to filter on fields that don't exist in the map.
 
- ex:
+ex:
 
- ```typescript
+```typescript
 const attributeMap = {
     id: 'id',
     createdAt: 'created_at'
 };
 ```
 
-#### 2. build the query query
+#### 2. build the query
 
 ```typescript
 // import the manager and relevant types
@@ -582,7 +582,7 @@ const resolver = async (obj, inputArgs) => {
 You can supply options to the `ConnectionManager` via the third parameter. Options are used to customize the `QueryContext`, the `QueryBuilder`, and the `QueryResult` classes.
 
 ```typescript
-    const options = { 
+    const options = {
       contextOptions: { ... }
       resultOptions: { ... }
       builderOptions: { ... }
@@ -597,7 +597,7 @@ Currently, the options are:
 ##### defaultLimit
 
 ```typescript
-number
+number;
 ```
 
 The default limit (page size) if none is specified in the `page` input params
@@ -616,7 +616,7 @@ interface ICursorEncoder<CursorObj> {
 ##### filterTransformer
 
 ```typescript
-type filterTransformer = (filter: IFilter) => IFilter
+type filterTransformer = (filter: IFilter) => IFilter;
 ```
 
 The filter transformer will will be called on every filter `{ field: string, operator: string, value: string}`
@@ -627,7 +627,7 @@ It can be used to transform a filter before being applied to the query. This is 
 
 ```typescript
 interface IFilterMap {
-  [operator: string]: string
+    [operator: string]: string;
 }
 ```
 
@@ -661,7 +661,7 @@ searchColumns: string[]
 Used with full text `Search` input. It is an array of column names that will be used in the full text search sql expression `MATCH (col1,col2,...) AGAINST (expr [search_modifier])`
 
 ```typescript
-searchColumns: string
+searchColumns: string;
 ```
 
 The values will likely be one of:
@@ -704,17 +704,17 @@ interface IQueryBuilder<Builder> {
 
 ## Architecture
 
-Internally, the `ConnectionManager` manages the orchestration of the `QueryContext`, `QueryBuilder`, and `QueryResult`. 
+Internally, the `ConnectionManager` manages the orchestration of the `QueryContext`, `QueryBuilder`, and `QueryResult`.
 
 The orchestration follows the steps:
 
-1. The `QueryContext` extracts the connection attributes from the input connection arguments. 
-2. The `QueryBuilder` (or `KnexQueryBuilder` in the default case) consumes the connection attributes and builds a query. The query is submitted to the database by the user and the result is sent to the `QueryResult`. 
+1. The `QueryContext` extracts the connection attributes from the input connection arguments.
+2. The `QueryBuilder` (or `KnexQueryBuilder` in the default case) consumes the connection attributes and builds a query. The query is submitted to the database by the user and the result is sent to the `QueryResult`.
 3. The `QueryResult` uses the result to build the `edges` (which contain a `cursor` and `node`) and extract the `page info`.
 
 This can be visualized as such:
 
-![Image of Architecture](https://docs.google.com/drawings/d/e/2PACX-1vRwtC2UiFwLXFDbmBNoq_6bD1YTyACV49SWHxfj2ce_K5T_XEZYlgGP7ntbcskoMVWqXp5C2Uj-K7Jj/pub?w=1163&amp;h=719)
+![Image of Architecture](https://docs.google.com/drawings/d/e/2PACX-1vRwtC2UiFwLXFDbmBNoq_6bD1YTyACV49SWHxfj2ce_K5T_XEZYlgGP7ntbcskoMVWqXp5C2Uj-K7Jj/pub?w=1163&h=719)
 
 ## Search
 
@@ -751,4 +751,75 @@ return {
     pageInfo: nodeConnection.pageInfo,
     edges: nodeConnection.edges
 };
+```
+
+## Filtering on computed columns
+
+Sometimes you may compute a field that depends on some other table than the one being paged over. In this case, you can use a derived table as your `from` and alias it to the primary table. In the following example we create a derived alias of "segment", the table we are paging over, to allow filtering and sorting on "popularity", a field computed on the aggregation of values from another table.
+
+```ts
+import {Resolver} from 'types/resolver';
+import {ISegmentNode} from 'types/graphql';
+import {segment as segmentTransformer} from 'transformers/sql_to_graphql';
+import {IQueryResult, IInputArgs, ConnectionManager} from 'graphql-connections';
+
+const attributeMap = {
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+    name: 'name',
+    explorer: 'explorer_id',
+    popularity: 'popularity'
+};
+
+const segments: Resolver<Promise<IQueryResult<ISegmentNode>>, undefined, IInputArgs> = async (
+    _,
+    input: IInputArgs,
+    ctx
+) => {
+    const {connection} = ctx.clients.sqlClient;
+
+    const queryBuilder = connection.queryBuilder().from(
+        connection.raw(
+            `(
+            select
+                segment.*,
+                coalesce(sum(user_segment.usage_count), 0) as popularity
+            from segment
+                     left join user_segment on user_segment.segment_id = segment.id
+            group by
+                segment.id
+        ) as segment`
+        )
+    );
+
+    const nodeConnection = new ConnectionManager<ISegmentNode>(input, attributeMap, {
+        builderOptions: {
+            filterTransformer(filter) {
+                if (filter.field === 'popularity') {
+                    return {
+                        field: 'popularity',
+                        operator: filter.operator,
+                        value: Number(filter.value) as any
+                    };
+                }
+
+                return filter;
+            }
+        },
+        resultOptions: {
+            nodeTransformer: segmentTransformer
+        }
+    });
+
+    const query = nodeConnection.createQuery(queryBuilder).select('*');
+
+    nodeConnection.addResult(await query);
+
+    return {
+        pageInfo: nodeConnection.pageInfo,
+        edges: nodeConnection.edges
+    };
+};
+
+export default segments;
 ```

--- a/__tests__/integration/__snapshots__/input_union_type.integration.test.ts.snap
+++ b/__tests__/integration/__snapshots__/input_union_type.integration.test.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Input Union Type handles errors not using variables with compound filter 1`] = `
-"{\\"errors\\":[{\\"message\\":\\"Expected type Filter, found {or: [{fields: \\\\\\"age\\\\\\", value: \\\\\\"41\\\\\\", operator: \\\\\\"=\\\\\\"}, {field: \\\\\\"age\\\\\\", value: \\\\\\"31\\\\\\", operator: \\\\\\"=\\\\\\"}, {and: [{field: \\\\\\"haircolor\\\\\\", value: \\\\\\"gray\\\\\\", operator: \\\\\\"=\\\\\\"}, {field: \\\\\\"age\\\\\\", value: \\\\\\"70\\\\\\", operator: \\\\\\"=\\\\\\"}, {not: [{field: \\\\\\"firstname\\\\\\", value: \\\\\\"Kenyon\\\\\\", operator: \\\\\\"=\\\\\\"}, {field: \\\\\\"firstname\\\\\\", value: \\\\\\"Nerissa\\\\\\", operator: \\\\\\"=\\\\\\"}]}]}]}; Filter should be composed of either: CompoundFilterScalar \`{and: [Filter], or: [Filter], not: [Filter]}\`, or FilterScalar \`{field: String, operator: String, value: String}\`\\",\\"locations\\":[{\\"line\\":4,\\"column\\":30}],\\"extensions\\":{\\"code\\":\\"GRAPHQL_VALIDATION_FAILED\\"}}]}
+"{\\"errors\\":[{\\"message\\":\\"Expected type Filter, found {or: [{fields: \\\\\\"age\\\\\\", value: \\\\\\"41\\\\\\", operator: \\\\\\"=\\\\\\"}, {field: \\\\\\"age\\\\\\", value: \\\\\\"31\\\\\\", operator: \\\\\\"=\\\\\\"}, {and: [{field: \\\\\\"haircolor\\\\\\", value: \\\\\\"gray\\\\\\", operator: \\\\\\"=\\\\\\"}, {field: \\\\\\"age\\\\\\", value: \\\\\\"70\\\\\\", operator: \\\\\\"=\\\\\\"}, {not: [{field: \\\\\\"firstname\\\\\\", value: \\\\\\"Kenyon\\\\\\", operator: \\\\\\"=\\\\\\"}, {field: \\\\\\"firstname\\\\\\", value: \\\\\\"Nerissa\\\\\\", operator: \\\\\\"=\\\\\\"}]}]}]}; Filter should be composed of either: CompoundFilterScalar \`{and: [Filter], or: [Filter], not: [Filter]}\`, or FilterScalar \`{field: String, operator: String, value: IntString}\`\\",\\"locations\\":[{\\"line\\":4,\\"column\\":30}],\\"extensions\\":{\\"code\\":\\"GRAPHQL_VALIDATION_FAILED\\"}}]}
 "
 `;
 
 exports[`Input Union Type handles errors not using variables with single filter 1`] = `
-"{\\"errors\\":[{\\"message\\":\\"Expected type Filter, found {fields: \\\\\\"haircolor\\\\\\", value: \\\\\\"gray\\\\\\", operator: \\\\\\"=\\\\\\"}; Filter should be composed of either: CompoundFilterScalar \`{and: [Filter], or: [Filter], not: [Filter]}\`, or FilterScalar \`{field: String, operator: String, value: String}\`\\",\\"locations\\":[{\\"line\\":4,\\"column\\":33}],\\"extensions\\":{\\"code\\":\\"GRAPHQL_VALIDATION_FAILED\\"}}]}
+"{\\"errors\\":[{\\"message\\":\\"Expected type Filter, found {fields: \\\\\\"haircolor\\\\\\", value: \\\\\\"gray\\\\\\", operator: \\\\\\"=\\\\\\"}; Filter should be composed of either: CompoundFilterScalar \`{and: [Filter], or: [Filter], not: [Filter]}\`, or FilterScalar \`{field: String, operator: String, value: IntString}\`\\",\\"locations\\":[{\\"line\\":4,\\"column\\":33}],\\"extensions\\":{\\"code\\":\\"GRAPHQL_VALIDATION_FAILED\\"}}]}
 "
 `;
 

--- a/__tests__/integration/input_args.integration.test.ts
+++ b/__tests__/integration/input_args.integration.test.ts
@@ -392,4 +392,30 @@ describe('Input args with', () => {
             expect(edges.length).toBe(0);
         });
     });
+
+    describe('Numeric and numeric string filters', () => {
+        it('Can be handled properly', async () => {
+            const filter = {
+                or: [
+                    {field: 'age', value: 41, operator: '='},
+                    {field: 'age', value: 31, operator: '='},
+                    {
+                        and: [
+                            {field: 'haircolor', value: 'gray', operator: '='},
+                            {field: 'age', value: 70, operator: '>'},
+                            {
+                                not: [{field: 'age', value: '80', operator: '>'}]
+                            }
+                        ]
+                    }
+                ]
+            };
+            const {pageInfo, edges} = await createConnection({filter});
+
+            expect(pageInfo.hasNextPage).toBe(false);
+            expect(pageInfo.hasPreviousPage).toBe(false);
+            expect(edges.length).toBe(10);
+            expect(edges[0].node.id).toBe(9321);
+        });
+    });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-connections",
-  "version": "7.0.3",
+  "version": "8.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1561,6 +1561,16 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -1782,9 +1792,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
     },
     "ci-info": {
@@ -3427,6 +3437,31 @@
           "bundled": true,
           "dev": true,
           "optional": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -5594,7 +5629,8 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5621,9 +5657,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
       "dev": true,
       "requires": {
         "debug": "^3.2.6",
@@ -5632,9 +5668,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -5660,11 +5696,67 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-addon-api": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -5710,9 +5802,9 @@
       },
       "dependencies": {
         "nopt": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "dev": true,
           "requires": {
             "abbrev": "1",
@@ -5726,6 +5818,21 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
+          }
+        },
+        "tar": {
+          "version": "4.4.13",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
           }
         }
       }
@@ -7030,14 +7137,14 @@
       "dev": true
     },
     "sqlite3": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.1.1.tgz",
-      "integrity": "sha512-CvT5XY+MWnn0HkbwVKJAyWEMfzpAPwnTiB3TobA5Mri44SrTovmmh499NPQP+gatkeOipqPlBLel7rn4E/PCQg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.0.1.tgz",
+      "integrity": "sha512-kh2lTIcYNfmVcvhVJihsYuPj9U0xzBbh6bmqILO2hkryWSC9RRhzYmkIDtJkJ+d8Kg4wZRJ0T1reyHUEspICfg==",
       "dev": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.11.0",
-        "request": "^2.87.0"
+        "node-addon-api": "^3.0.0",
+        "node-gyp": "3.x",
+        "node-pre-gyp": "^0.11.0"
       }
     },
     "sqlstring": {
@@ -7275,18 +7382,15 @@
       "dev": true
     },
     "tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
+      "optional": true,
       "requires": {
-        "chownr": "^1.1.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.8.6",
-        "minizlib": "^1.2.1",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
       }
     },
     "tarn": {
@@ -7660,9 +7764,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "graphql-connections",
-    "version": "7.0.4",
+    "version": "8.0.0",
     "description": "Build and handle Relay-like GraphQL connections using a Knex query builder",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",

--- a/package.json
+++ b/package.json
@@ -78,13 +78,13 @@
         "rimraf": "^3.0.2",
         "rollup": "^1.2.2",
         "rollup-plugin-typescript2": "^0.24.3",
-        "sqlite3": "^4.1.1",
+        "sqlite3": "5.0.1",
         "supertest": "^4.0.2",
         "ts-jest": "^24.0.0",
         "ts-node": "^8.0.3",
         "tsconfig-paths": "^3.8.0",
         "tslint": "^5.13.1",
         "tslint-eslint-rules": "^5.4.0",
-        "typescript": "^3.3.3333"
+        "typescript": "4.1.3"
     }
 }

--- a/src/graphql_schema.ts
+++ b/src/graphql_schema.ts
@@ -28,6 +28,7 @@ const coerceIntString = (value: number | string) => {
     return String(value);
 };
 
+/** @see https://stackoverflow.com/a/49911974 */
 const intString = new GraphQLScalarType({
     name: 'IntString',
     serialize: coerceIntString,

--- a/src/graphql_schema.ts
+++ b/src/graphql_schema.ts
@@ -28,7 +28,7 @@ const coerceIntString = (value: number | string) => {
     return String(value);
 };
 
-const IntString = new GraphQLScalarType({
+const intString = new GraphQLScalarType({
     name: 'IntString',
     serialize: coerceIntString,
     parseValue: coerceIntString,
@@ -71,7 +71,7 @@ const filterScalar = new GraphQLInputObjectType({
                 type: GraphQLString
             },
             value: {
-                type: IntString
+                type: intString
             }
         };
     }

--- a/src/query_builder/knex_base.ts
+++ b/src/query_builder/knex_base.ts
@@ -118,10 +118,15 @@ export default class KnexQueryBuilder implements IQueryBuilder<Knex> {
     private filterArgs(filter: IFilter) {
         const transformedFilter = this.filterTransformer(filter);
 
+        const filterIsNullComparison =
+            transformedFilter.value === null ||
+            (typeof transformedFilter.value === 'string' &&
+                transformedFilter.value.toLowerCase() === 'null');
+
         if (
             this.useSuggestedValueLiteralTransforms &&
-            transformedFilter.operator.toLowerCase() === '=' &&
-            (transformedFilter.value === null || transformedFilter.value.toLowerCase() === 'null')
+            filterIsNullComparison &&
+            transformedFilter.operator.toLowerCase() === '='
         ) {
             return [
                 (builder: QueryBuilder) => {
@@ -132,8 +137,8 @@ export default class KnexQueryBuilder implements IQueryBuilder<Knex> {
 
         if (
             this.useSuggestedValueLiteralTransforms &&
-            transformedFilter.operator.toLowerCase() === '<>' &&
-            (transformedFilter.value === null || transformedFilter.value.toLowerCase() === 'null')
+            filterIsNullComparison &&
+            transformedFilter.operator.toLowerCase() === '<>'
         ) {
             return [
                 (builder: QueryBuilder) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import {ORDER_DIRECTION} from './enums';
 export interface IFilter {
     value: string;
     operator: string;
-    field: string;
+    field: string | number | null;
 }
 
 export interface ICompoundFilter {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import {ORDER_DIRECTION} from './enums';
 
 export interface IFilter {
-    value: string;
+    value: string | number | null;
     operator: string;
-    field: string | number | null;
+    field: string;
 }
 
 export interface ICompoundFilter {


### PR DESCRIPTION
Allows string, number or null as input to `filter.value`.

```graphql
# Write your query or mutation here
query {
  segments(
    first: 3,
    filter: {
      field: "popularity"
      operator: ">="
      value: 3000
    }
	) {
    edges {
      node {
        id
        popularity
      }
    }
  }
}
```