### PR TITLE
Composable filter transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,8 @@ The filter transformer will will be called on every filter `{ field: string, ope
 
 It can be used to transform a filter before being applied to the query. This is useful if you want to transform say UnixTimestamps to DateTime format, etc...
 
+See the [filter transformation section for more details](#filter-transformation).
+
 ##### filterMap
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -832,10 +832,14 @@ Sometimes you may have a completely different data type in a filter from what is
 ```ts
 import {FilterTransformers} from 'graphql-connections';
 
-const timestampFilterTransformer = FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps([
-    'createdAt',
-    'updatedAt'
-]);
+type SomeGraphQLNode = {
+    createdAt: string | number;
+    updatedAt: string | number;
+};
+
+const timestampFilterTransformer = FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps<
+    SomeGraphQLNode
+>(['createdAt', 'updatedAt']);
 
 const nodeConnection = new ConnectionManager<GqlActualDistribution | null>(input, inAttributeMap, {
     builderOptions: {

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
   - [Search](#search)
   - [Filtering on computed columns](#filtering-on-computed-columns)
   - [Filter Transformation](#filter-transformation)
+    - [Filter Transformers provided by this library](#filter-transformers-provided-by-this-library)
+      - [FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps](#filtertransformerscastunixsecondsfilterstomysqltimestamps)
 
 ## Install
 
@@ -871,3 +873,23 @@ const nodeConnection = new ConnectionManager<GqlActualDistribution | null>(input
     resultOptions: {nodeTransformer: sqlToGraphql.actualDistribution}
 });
 ```
+
+### Filter Transformers provided by this library
+
+#### FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps
+
+`castUnixSecondsFiltersToMysqlTimestamps` takes four arguments
+
+```ts
+function castUnixSecondsFiltersToMysqlTimestamps<T extends Record<string, unknown>>(
+    filterFieldsToCast: Array<keyof T>,
+    timezone: DateTimeOptions['zone'] = 'UTC',
+    includeOffset = false,
+    includeZone = false
+): FilterTransformer;
+```
+
+`filterFieldsToCast` refers to the keys in a graphql node being filtered upon that will be transformed from unix seconds to MySQL timestamps.
+`timezone` is the expected timezone of the input seconds. **Default: UTC**
+`includeOffset` dictates whether the timestamp offset will be included in the generated timestamp **Default: false**
+`includeZone` dictates whether the timestamp's timezone will be included in the generated timestamp **Default: false**

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
   - [Architecture](#architecture)
   - [Search](#search)
   - [Filtering on computed columns](#filtering-on-computed-columns)
+  - [Filter Transformation](#filter-transformation)
 
 ## Install
 
@@ -822,4 +823,45 @@ const segments: Resolver<Promise<IQueryResult<ISegmentNode>>, undefined, IInputA
 };
 
 export default segments;
+```
+
+## Filter Transformation
+
+Sometimes you may have a completely different data type in a filter from what is actually in your database. At Social Native, for example, our graph exposes all timestamps as Unix Seconds, but in our databases, the `timestamp` type is used. In order to easily manage filter value transformation from seconds to sql timestamps, we use the `filterTransformer` option. In the following example, we use the library-provided `FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps` which takes a list of field names that should be transformed from unix seconds to mysql timestamps, if they are present and not falsy.
+
+```ts
+import {FilterTransformers} from 'graphql-connections';
+
+const timestampFilterTransformer = FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps([
+    'createdAt',
+    'updatedAt'
+]);
+
+const nodeConnection = new ConnectionManager<GqlActualDistribution | null>(input, inAttributeMap, {
+    builderOptions: {
+        filterTransformer: timestampFilterTransformer
+    },
+    resultOptions: {nodeTransformer: sqlToGraphql.actualDistribution}
+});
+```
+
+A `compose` function is also exposed to combine multiple transformers together. The following example composes a transformer on 'createdAt', 'updatedAt' with one on 'startedAt', 'completedAt', creating one that will cast if any of the four were given.
+
+```ts
+import {FilterTransformers} from 'graphql-connections';
+
+const timestampFilterTransformer = FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps([
+    'createdAt',
+    'updatedAt'
+]);
+
+const nodeConnection = new ConnectionManager<GqlActualDistribution | null>(input, inAttributeMap, {
+    builderOptions: {
+        filterTransformer: FilterTransformers.compose(
+            timestampFilterTransformer,
+            FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps(['startedAt', 'completedAt'])
+        )
+    },
+    resultOptions: {nodeTransformer: sqlToGraphql.actualDistribution}
+});
 ```

--- a/__tests__/integration/filter_transformers.test.ts
+++ b/__tests__/integration/filter_transformers.test.ts
@@ -17,7 +17,7 @@ describe('Filter Transformers', function() {
                 Object {
                   "field": "createdAt",
                   "operator": "=",
-                  "value": "2021-07-27 01:30:46.000",
+                  "value": "2021-07-27 08:30:46.000",
                 }
             `);
         });
@@ -48,7 +48,7 @@ describe('Filter Transformers', function() {
                 Object {
                   "field": "createdAt",
                   "operator": "=",
-                  "value": "2021-07-27 01:30:46.000",
+                  "value": "2021-07-27 08:30:46.000",
                 }
             `);
 
@@ -62,7 +62,7 @@ describe('Filter Transformers', function() {
                 Object {
                   "field": "updatedAt",
                   "operator": "=",
-                  "value": "2021-07-27 01:30:46.000",
+                  "value": "2021-07-27 08:30:46.000",
                 }
             `);
         });

--- a/__tests__/integration/filter_transformers.test.ts
+++ b/__tests__/integration/filter_transformers.test.ts
@@ -1,0 +1,70 @@
+import FilterTransformers from '../../src/filter_transformers';
+
+describe('Filter Transformers', function() {
+    describe('castUnixSecondsFiltersToMysqlTimestamps', function() {
+        it('converts the unix seconds filters to mySQL timestamps', function() {
+            const transformer = FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps<{
+                createdAt: string;
+            }>(['createdAt']);
+
+            expect(
+                transformer({
+                    field: 'createdAt',
+                    operator: '=',
+                    value: 1627374646
+                })
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "field": "createdAt",
+                  "operator": "=",
+                  "value": "2021-07-27 01:30:46.000",
+                }
+            `);
+        });
+    });
+
+    describe('compose', function() {
+        it('composes multiple transformers together from left to right', function() {
+            const createdAtTransformer = FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps(
+                ['createdAt']
+            );
+
+            const updatedAtTransformer = FilterTransformers.castUnixSecondsFiltersToMysqlTimestamps(
+                ['updatedAt']
+            );
+
+            const filterTransformer = FilterTransformers.compose(
+                createdAtTransformer,
+                updatedAtTransformer
+            );
+
+            expect(
+                filterTransformer({
+                    field: 'createdAt',
+                    operator: '=',
+                    value: 1627374646
+                })
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "field": "createdAt",
+                  "operator": "=",
+                  "value": "2021-07-27 01:30:46.000",
+                }
+            `);
+
+            expect(
+                filterTransformer({
+                    field: 'updatedAt',
+                    operator: '=',
+                    value: 1627374646
+                })
+            ).toMatchInlineSnapshot(`
+                Object {
+                  "field": "updatedAt",
+                  "operator": "=",
+                  "value": "2021-07-27 01:30:46.000",
+                }
+            `);
+        });
+    });
+});

--- a/depcheck.options.json
+++ b/depcheck.options.json
@@ -19,7 +19,8 @@
         "mysql2",
         "@social-native/snpkg-dependency-check",
         "@social-native/snpkg-generate-config-ci",
-        "@social-native/snpkg-package-version-validation"
+        "@social-native/snpkg-package-version-validation",
+        "@types/luxon"
     ],
     "specials": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,23 @@
 {
     "name": "graphql-connections",
-    "version": "8.0.0",
+    "version": "9.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "graphql-connections",
-            "version": "8.0.0",
+            "version": "9.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "graphql": "14.7.0",
-                "knex": "0.20.13"
+                "knex": "0.20.13",
+                "luxon": "2.0.1"
             },
             "devDependencies": {
                 "@types/dotenv": "^6.1.1",
                 "@types/faker": "^4.1.5",
                 "@types/jest": "^24.0.9",
+                "@types/luxon": "1.27.1",
                 "@types/superagent": "^4.1.1",
                 "@types/supertest": "^2.0.7",
                 "apollo-server-koa": "^2.4.8",
@@ -896,6 +898,12 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
             "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+            "dev": true
+        },
+        "node_modules/@types/luxon": {
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.27.1.tgz",
+            "integrity": "sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==",
             "dev": true
         },
         "node_modules/@types/mime": {
@@ -6465,6 +6473,14 @@
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "devOptional": true
         },
+        "node_modules/luxon": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.0.1.tgz",
+            "integrity": "sha512-8Eawf81c9ZlQj62W3eq4mp+C7SAIAnmaS7ZuEAiX503YMcn+0C1JnMQRtfaQj6B5qTZLgHv0F4H5WabBCvi1fw==",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/make-dir": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -10720,6 +10736,12 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
             "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+            "dev": true
+        },
+        "@types/luxon": {
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.27.1.tgz",
+            "integrity": "sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==",
             "dev": true
         },
         "@types/mime": {
@@ -15252,6 +15274,11 @@
                     "devOptional": true
                 }
             }
+        },
+        "luxon": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.0.1.tgz",
+            "integrity": "sha512-8Eawf81c9ZlQj62W3eq4mp+C7SAIAnmaS7ZuEAiX503YMcn+0C1JnMQRtfaQj6B5qTZLgHv0F4H5WabBCvi1fw=="
         },
         "make-dir": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "graphql-connections",
-    "version": "9.0.0",
+    "version": "9.1.0",
     "description": "Build and handle Relay-like GraphQL connections using a Knex query builder",
     "main": "dist/index.cjs.js",
     "module": "dist/index.es.js",
@@ -57,7 +57,8 @@
     "homepage": "https://github.com/social-native/graphql-connections#readme",
     "dependencies": {
         "knex": "0.20.13",
-        "graphql": "14.7.0"
+        "graphql": "14.7.0",
+        "luxon": "2.0.1"
     },
     "devDependencies": {
         "@types/dotenv": "^6.1.1",
@@ -65,6 +66,7 @@
         "@types/jest": "^24.0.9",
         "@types/superagent": "^4.1.1",
         "@types/supertest": "^2.0.7",
+        "@types/luxon": "1.27.1",
         "apollo-server-koa": "^2.4.8",
         "dotenv": "^8.0.0",
         "faker": "^4.1.0",

--- a/src/filter_transformers.ts
+++ b/src/filter_transformers.ts
@@ -1,5 +1,4 @@
-import {DateTime} from 'luxon';
-import type {DateTimeOptions} from 'luxon';
+import {DateTime, DateTimeOptions} from 'luxon';
 import {FilterTransformer, IFilter} from './types';
 
 /**

--- a/src/filter_transformers.ts
+++ b/src/filter_transformers.ts
@@ -1,0 +1,46 @@
+import {DateTime} from 'luxon';
+import {FilterTransformer, IFilter} from './types';
+
+/** Given filter values in unix seconds, this will convert the filters to mysql timestamps. */
+function castUnixSecondsFiltersToMysqlTimestamps<T extends Record<string, unknown>>(
+    filterFieldsToCast: Array<keyof T>,
+    includeOffset = false,
+    includeZone = false
+): FilterTransformer {
+    // tslint:disable-next-line: cyclomatic-complexity
+    return (filter: IFilter): IFilter => {
+        if (filterFieldsToCast.includes(filter.field) && filter.value && filter.value !== 'null') {
+            if (!isNumberOrString(filter.value)) {
+                throw new Error(`Cannot parse timestamp filter: ${filter.field}`);
+            }
+
+            const filterValue =
+                typeof filter.value === 'string' ? Number(filter.value) : filter.value;
+
+            return {
+                ...filter,
+                value: DateTime.fromSeconds(filterValue).toSQL({
+                    includeOffset,
+                    includeZone
+                })
+            };
+        }
+        return filter;
+    };
+}
+
+function isNumberOrString(value: string | number | boolean): value is string | number {
+    return ['number', 'string'].includes(typeof value);
+}
+
+/**
+ * Run a number of filter transformers from left to right on an IFilter.
+ */
+function compose(...transformers: FilterTransformer[]): FilterTransformer {
+    return (filter: IFilter) =>
+        transformers.reduce((accum, transformer) => {
+            return transformer(accum);
+        }, filter);
+}
+
+export default {castUnixSecondsFiltersToMysqlTimestamps, compose};

--- a/src/filter_transformers.ts
+++ b/src/filter_transformers.ts
@@ -1,9 +1,13 @@
 import {DateTime} from 'luxon';
+import type {DateTimeOptions} from 'luxon';
 import {FilterTransformer, IFilter} from './types';
 
-/** Given filter values in unix seconds, this will convert the filters to mysql timestamps. */
+/**
+ * Given filter values in unix seconds, this will convert the filters to mysql timestamps
+ */
 function castUnixSecondsFiltersToMysqlTimestamps<T extends Record<string, unknown>>(
     filterFieldsToCast: Array<keyof T>,
+    timezone: DateTimeOptions['zone'] = 'UTC',
     includeOffset = false,
     includeZone = false
 ): FilterTransformer {
@@ -19,7 +23,7 @@ function castUnixSecondsFiltersToMysqlTimestamps<T extends Record<string, unknow
 
             return {
                 ...filter,
-                value: DateTime.fromSeconds(filterValue, {zone: 'UTC'}).toSQL({
+                value: DateTime.fromSeconds(filterValue, {zone: timezone}).toSQL({
                     includeOffset,
                     includeZone
                 })

--- a/src/filter_transformers.ts
+++ b/src/filter_transformers.ts
@@ -19,7 +19,7 @@ function castUnixSecondsFiltersToMysqlTimestamps<T extends Record<string, unknow
 
             return {
                 ...filter,
-                value: DateTime.fromSeconds(filterValue).toSQL({
+                value: DateTime.fromSeconds(filterValue, {zone: 'UTC'}).toSQL({
                     includeOffset,
                     includeZone
                 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export {default as ConnectionManager} from './connection_manager';
 export {default as QueryContext} from './query_context';
 export {default as QueryResult} from './query_result';
 export {default as CursorEncoder} from './cursor_encoder';
+export {default as FilterTransformers} from './filter_transformers';
 export {Knex, KnexMySQL} from './query_builder';
 
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export interface ICompoundFilter {
 
 export type IInputFilter = IFilter | ICompoundFilter;
 
+export type FilterTransformer = (filter: IFilter) => IFilter;
+
 export interface ICursorObj<PublicAttributes> {
     orderDir: keyof typeof ORDER_DIRECTION;
     orderBy: PublicAttributes;
@@ -77,13 +79,13 @@ export type QueryBuilderOptions = IKnexQueryBuilderOptions | IKnexMySQLQueryBuil
 
 export interface IKnexQueryBuilderOptions {
     filterMap?: {[operator: string]: string};
-    filterTransformer?: (filter: IFilter) => IFilter;
+    filterTransformer?: FilterTransformer;
     useSuggestedValueLiteralTransforms?: boolean;
 }
 
 export interface IKnexMySQLQueryBuilderOptions extends IKnexQueryBuilderOptions {
     filterMap?: {[operator: string]: string};
-    filterTransformer?: (filter: IFilter) => IFilter;
+    filterTransformer?: FilterTransformer;
     useSuggestedValueLiteralTransforms?: boolean;
     searchColumns?: string[];
     searchModifier?:


### PR DESCRIPTION
This gives a reusable utility for transforming unix seconds to MySQL timestamps. Additionally, a `compose` function is available for combining multiple filter transformers.